### PR TITLE
Added uidmap package in order to be able to build container images using img

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,7 @@ RUN apt-get update \
 		rpm \
 		ansible \
 		procps \
+		uidmap \
 	&& rm -rf /var/lib/apt/lists/*
 
 


### PR DESCRIPTION
As specified in the documentation of [img](https://github.com/genuinetools/img), it requires the package uidmap.